### PR TITLE
fix: guard hysteria2 authenticateAndWrap against a nil QUIC connection

### DIFF
--- a/hysteria2/client.go
+++ b/hysteria2/client.go
@@ -250,6 +250,18 @@ func (c *Client) authenticateAndWrap(ctx context.Context, packetDialer qtls.Pack
 	if err != nil {
 		return nil, err
 	}
+	// A QuicDialer must return a non-nil connection whenever it returns a nil
+	// error. Some implementations can violate this contract (e.g. an inner
+	// QUIC dial racing connection teardown returns (nil, nil)). Without this
+	// guard the nil quicConn is captured by the http3.Transport Dial closure
+	// below and later dereferenced in http3.newClientConn (conn.QlogTrace()),
+	// crashing the whole process with a nil-pointer panic.
+	if quicConn == nil {
+		if packetConn != nil {
+			_ = packetConn.Close()
+		}
+		return nil, E.New("hysteria2: QUIC dialer returned a nil connection without an error")
+	}
 
 	http3Transport := &http3.Transport{
 		TLSClientConfig: c.tlsConfig,

--- a/hysteria2/client_nilconn_test.go
+++ b/hysteria2/client_nilconn_test.go
@@ -1,0 +1,37 @@
+package hysteria2
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/metacubex/quic-go"
+	qtls "github.com/metacubex/sing-quic"
+	"github.com/metacubex/tls"
+)
+
+// TestOfferNewNilQuicConn verifies that offerNew returns an error instead of
+// crashing when the QUIC dialer returns a nil *quic.Conn together with a nil
+// error.
+//
+// A QuicDialer must return a non-nil connection whenever it returns a nil
+// error. When an implementation violates that contract, the nil conn used to
+// be captured by the http3.Transport Dial closure and later dereferenced in
+// http3.newClientConn (conn.QlogTrace()), crashing the whole process with a
+// nil-pointer panic in a goroutine spawned by http3.Transport.getClient.
+func TestOfferNewNilQuicConn(t *testing.T) {
+	c := &Client{
+		ctx: context.Background(),
+		quicDialer: qtls.QuicDialerFunc(func(ctx context.Context, addr string, listener qtls.PacketDialer, tlsCfg *tls.Config, cfg *quic.Config, early bool) (net.PacketConn, *quic.Conn, error) {
+			return nil, nil, nil // contract violation: nil conn, nil error
+		}),
+	}
+
+	conn, err := c.offerNew(context.Background())
+	if err == nil {
+		t.Fatal("offerNew with nil quicConn: got nil error, want a non-nil error")
+	}
+	if conn != nil {
+		t.Fatalf("offerNew with nil quicConn: got non-nil connection %v, want nil", conn)
+	}
+}


### PR DESCRIPTION
## Problem

A service using the hysteria2 client crashes intermittently with:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x438]

github.com/metacubex/quic-go.(*Conn).QlogTrace(...)
	quic-go/connection.go:3132
github.com/metacubex/quic-go/http3.newClientConn(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	quic-go/http3/client.go:93
github.com/metacubex/quic-go/http3.(*Transport).dial(...)
	quic-go/http3/transport.go:386
created by github.com/metacubex/quic-go/http3.(*Transport).getClient
```

All six arguments to `newClientConn` are `0x0` — the `*quic.Conn` is nil.

## Root cause

`authenticateAndWrap` checks only the **error** returned by `QuicDialer.DialContext`, not the connection:

```go
packetConn, quicConn, err := c.quicDialer.DialContext(...)
if err != nil {
    return nil, err
}
http3Transport := &http3.Transport{
    ...
    Dial: func(...) (*quic.Conn, error) {
        return quicConn, nil   // returns nil quicConn with a nil error
    },
}
```

A `QuicDialer` must return a non-nil connection whenever it returns a nil error, but an implementation can violate this — e.g. an inner QUIC dial that races connection teardown can return `(nil, nil)`. The nil `quicConn` is then captured by the `http3.Transport.Dial` closure and returned verbatim. `http3`'s own `Transport.dial` does not nil-check the connection either, so `http3.newClientConn` receives a nil `*quic.Conn` and dereferences it in `conn.QlogTrace()`, crashing the whole process — and the panic happens in a goroutine spawned by `http3.Transport.getClient`, so it cannot be recovered by the caller.

## Fix

Reject a nil connection right after the dial: close the packet conn if present and return an error. The auth attempt then fails cleanly (the caller already handles a dial error) instead of panicking the process.

## Test

`hysteria2/client_nilconn_test.go` drives `offerNew` with a `QuicDialer` that returns `(nil, nil, nil)`:
- on `main` it reproduces the panic (`SIGSEGV addr=0x438`);
- with the fix it returns a clean error.

## Note (unrelated)

Building `main` currently fails with a missing `golang.org/x/sync` go.sum entry — the new `hysteria2/realm` package imports `golang.org/x/sync/singleflight`, but `go.mod`/`go.sum` were not updated (`go mod tidy` needed). This is unrelated to this change and not included here to keep the PR focused; verified locally with `golang.org/x/sync` added.